### PR TITLE
Add interceptor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A robust Flutter WebSocket plugin utilizing the Adapter design pattern for flexi
 - **Advanced Monitoring**: Comprehensive connection and heartbeat metrics
 - **Health Monitoring**: Track connection quality and performance
 - **Detailed Logging**: Enhanced debugging with heartbeat and reconnection logs
+- **Interceptors**: Customize processing of outgoing and incoming messages
 
 ## Installation
 

--- a/lib/src/websocket_interceptor.dart
+++ b/lib/src/websocket_interceptor.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+
+import 'websocket_message.dart';
+
+/// Allows interception of messages sent or received through [WebSocketClient].
+///
+/// Implementations can inspect, modify or replace messages. Returning a new
+/// [WebSocketMessage] from either method will cause that message to be used in
+/// place of the original.
+abstract class WebSocketInterceptor {
+  /// Called before a message is sent. The returned [WebSocketMessage] will be
+  /// forwarded to the underlying adapter.
+  FutureOr<WebSocketMessage> onSend(WebSocketMessage message) => message;
+
+  /// Called for each incoming message before it is exposed via
+  /// [WebSocketClient.messageStream]. The returned message will be emitted to
+  /// listeners.
+  FutureOr<WebSocketMessage> onReceive(WebSocketMessage message) => message;
+}

--- a/lib/websocket_plugin.dart
+++ b/lib/websocket_plugin.dart
@@ -7,3 +7,4 @@ export 'src/websocket_message.dart';
 export 'src/websocket_state.dart';
 export 'src/adapters/web_socket_channel_adapter.dart';
 export 'src/adapters/mock_websocket_adapter.dart';
+export 'src/websocket_interceptor.dart';

--- a/test/interceptor_test.dart
+++ b/test/interceptor_test.dart
@@ -1,0 +1,59 @@
+import 'package:adapter_websocket/websocket_plugin.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TestInterceptor implements WebSocketInterceptor {
+  final List<String> events;
+  _TestInterceptor(this.events);
+
+  @override
+  Future<WebSocketMessage> onSend(WebSocketMessage message) async {
+    events.add('send:${message.data}');
+    return WebSocketMessage.now(data: '${message.data}-out');
+  }
+
+  @override
+  Future<WebSocketMessage> onReceive(WebSocketMessage message) async {
+    events.add('recv:${message.data}');
+    return WebSocketMessage.now(data: '${message.data}-in');
+  }
+}
+
+void main() {
+  group('WebSocketInterceptor', () {
+    late MockWebSocketAdapter adapter;
+    late WebSocketClient client;
+    late List<String> events;
+
+    setUp(() {
+      final config = WebSocketConfig(url: 'wss://test.example.com');
+      adapter = MockWebSocketAdapter(config);
+      events = <String>[];
+      client = WebSocketClient(adapter, interceptors: [_TestInterceptor(events)]);
+    });
+
+    tearDown(() async {
+      await client.dispose();
+    });
+
+    test('outgoing messages are intercepted', () async {
+      await adapter.connect();
+      await client.sendText('hello');
+
+      expect(adapter.sentMessages.first.data, equals('hello-out'));
+      expect(events, contains('send:hello'));
+    });
+
+    test('incoming messages are intercepted', () async {
+      await adapter.connect();
+
+      final received = <WebSocketMessage>[];
+      client.messageStream.listen(received.add);
+
+      adapter.simulateTextMessage('server');
+      await Future.delayed(Duration(milliseconds: 10));
+
+      expect(received.first.data, equals('server-in'));
+      expect(events, contains('recv:server'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add message interceptor interface
- allow registering interceptors in `WebSocketClient`
- expose interceptors from plugin
- test interceptors and document feature

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6479b4c883248c46c1805b401078