### PR TITLE
fix: Messages containing "ping/pong" would be detected as heartbeat!

### DIFF
--- a/lib/src/adapters/web_socket_channel_adapter.dart
+++ b/lib/src/adapters/web_socket_channel_adapter.dart
@@ -166,7 +166,7 @@ class WebSocketChannelAdapter implements WebSocketAdapter {
 
       if (data is String) {
         // Check if it's a heartbeat response
-        if (_isHeartbeatMessage(data)) {
+        if (_config.enableHeartbeat && _isHeartbeatMessage(data)) {
           message = WebSocketMessage(
             data: data,
             timestamp: DateTime.now(),
@@ -215,11 +215,9 @@ class WebSocketChannelAdapter implements WebSocketAdapter {
 
   /// Checks if a message is a heartbeat message
   bool _isHeartbeatMessage(String message) {
-    final lowerMessage = message.toLowerCase();
-    return lowerMessage == 'pong' ||
-        lowerMessage == _config.expectedPongMessage?.toLowerCase() ||
-        lowerMessage.contains('ping') ||
-        lowerMessage.contains('pong');
+    if (_config.expectedPongMessage == null && _config.expectedPongMessagePattern == null) return false;
+
+    return message == _config.expectedPongMessage || _config.expectedPongMessagePattern!.hasMatch(message);
   }
 
   @override

--- a/lib/src/websocket_config.dart
+++ b/lib/src/websocket_config.dart
@@ -19,6 +19,7 @@ class WebSocketConfig {
   final Duration heartbeatTimeout;
   final String heartbeatMessage;
   final String? expectedPongMessage;
+  final RegExp? expectedPongMessagePattern;
   final int maxMissedHeartbeats;
   final bool useExponentialBackoff;
   final Duration maxReconnectDelay;
@@ -40,6 +41,7 @@ class WebSocketConfig {
     this.heartbeatTimeout = const Duration(seconds: 10),
     this.heartbeatMessage = 'ping',
     this.expectedPongMessage,
+    this.expectedPongMessagePattern,
     this.maxMissedHeartbeats = 3,
     this.useExponentialBackoff = true,
     this.maxReconnectDelay = const Duration(minutes: 5),


### PR DESCRIPTION
I noticed that the current way of checking for a heartbeat type message is too aggressive and will trigger if the content of the WS message contains `ping` or `pong` even as part of a word, e.g., `sweeping_accel `.

The change aims to resolve this by restricting the check to what the user has defined. There should never be a need for an implicit pong/ping check, and therefore, I removed it. 